### PR TITLE
breadcrumbs_userMypage_setting_commit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,30 +75,19 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
 gem 'haml-rails'
-
 gem 'devise'
-
 gem 'ancestry', '~> 3.0.7'
-
 gem 'font-awesome-sass'
-
 gem 'carrierwave'
-
 gem 'mini_magick'
-
 gem 'pry-rails'
-
 gem 'active_hash'
-
 gem 'payjp'
-
 gem "jquery-rails"
-
 gem 'dotenv-rails'
-
 gem 'fog-aws'
-
 gem 'omniauth-google-oauth2'
 gem "omniauth-rails_csrf_protection"
+gem 'gretel'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -399,6 +401,7 @@ DEPENDENCIES
   factory_bot_rails
   fog-aws
   font-awesome-sass
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,22 @@
 @import "addresses";
 @import "templates/sub_foot_template";
 @import "search";
+
+.breadcrumbs {
+  font-size: 12px;
+  padding: 20px 190px;
+  border-bottom: 1px solid lightgray;
+  a {
+    text-decoration: none;
+    margin: 0 10px;
+    color: black;
+  }
+  a:hover {
+    color: #FFC36F;
+    border-bottom: 1px solid #FFC36F;
+    }
+  .current {
+    margin-left: 10px;
+    font-weight: 600;
+  }
+}

--- a/app/assets/stylesheets/templates/_head_template.scss
+++ b/app/assets/stylesheets/templates/_head_template.scss
@@ -3,7 +3,8 @@
 }
 
 .header-grp {
-  
+  border-bottom: 1px solid lightgray;
+  padding-bottom: 20px;
 &__header {
   height: 100px;
   background-color: #fff;

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -1,4 +1,6 @@
 = render "/items/templates/head_template"
+- breadcrumb :addressFix
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 .addresseMain
   = render "/users/users_side"
   .addresseMain__wrapper

--- a/app/views/addresses/new.html.haml
+++ b/app/views/addresses/new.html.haml
@@ -1,4 +1,6 @@
 = render "/items/templates/head_template"
+- breadcrumb :addressRegister
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 .addresseMain
   = render "/users/users_side"
   .addresseMain__wrapper

--- a/app/views/cards/confirmation.html.haml
+++ b/app/views/cards/confirmation.html.haml
@@ -1,4 +1,6 @@
 = render "/items/templates/head_template"
+- breadcrumb :confirmationCard
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 .Cards
   = render "/users/users_side"
   .ShowCard

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,4 +1,6 @@
 = render "/items/templates/head_template"
+- breadcrumb :profile
+= breadcrumbs pretext: "",separator: " &rsaquo; " 
 .userEdit
   = render "/users/users_side"
   .userEdit__wrapper

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,4 +1,6 @@
 = render "/items/templates/head_template"
+- breadcrumb :mypage
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 .users__main
   = render "users_side"
   .users__main__right

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,27 @@
+crumb :root do
+  link "トップページ", root_path
+end
+
+crumb :mypage do
+  link "マイページ", users_path
+end
+
+crumb :profile do
+  link "本人情報変更", edit_user_registration_path
+  parent :mypage
+end
+
+crumb :addressRegister do
+  link "住所登録", new_address_path
+  parent :mypage
+end
+
+crumb :addressFix do
+  link "住所変更", edit_address_path(current_user)
+  parent :mypage
+end
+
+crumb :confirmationCard do
+  link "カード情報確認", confirmation_card_path(current_user)
+  parent :mypage
+end


### PR DESCRIPTION
# What
マイページのパンくず機能実装

# Why
マイページは遷移先が多く、ユーザーが今どこに居るのかを明示した方が
ユーザーファーストだと考えたため。

<img width="1281" alt="450156a532c976f96c5d0a9568f9c6dd" src="https://user-images.githubusercontent.com/58877984/78748698-9f758580-79a7-11ea-8916-e7139ab2f955.png">